### PR TITLE
Remove googleProvider from assests

### DIFF
--- a/src/web/templates/contribute.html
+++ b/src/web/templates/contribute.html
@@ -219,7 +219,6 @@
 	
 	{% assets filters="jsmin", output="assets/packaged-contribute.js",
             "lib/npm_components/leaflet-geosearch/dist/bundle.min.js", 
-            "lib/npm_components/leaflet-geosearch/lib/providers/googleProvider.js",
             "lib/npm_components/leaflet-label/dist/leaflet.label.js",
             "lib/npm_components/leaflet-image/leaflet-image.js",
             "lib/custom/tooltip/tooltip.js",


### PR DESCRIPTION
Fix `exports is not defined error`. 
lib/npm_components/leaflet-geosearch/lib/providers/googleProvider.js not transpiled which is causing the problem.